### PR TITLE
New getMaxCurrent function and modified setVoltage function 

### DIFF
--- a/AP33772.cpp
+++ b/AP33772.cpp
@@ -281,6 +281,22 @@ int AP33772::readCurrent()
 }
 
 /**
+ * @brief Read maximum VBUS current
+ * @return current in mA
+ */
+int AP33772::getMaxCurrent() const
+{
+    if (indexPDO == PPSindex)
+    {
+        return pdoData[PPSindex].pps.maxCurrent * 50;
+    }
+    else
+    {
+        return pdoData[indexPDO].fixed.maxCurrent * 10;
+    }
+}
+
+/**
  * @brief Read NTC temperature
  * @return tempearture in C
  */

--- a/AP33772.cpp
+++ b/AP33772.cpp
@@ -85,18 +85,15 @@ void AP33772::setVoltage(int targetVoltage)
     Step 3: Compare found PDOs votlage and PPS max voltage
     */
     byte tempIndex = 0;
-    if (existPPS)
+    if ((existPPS) && (pdoData[PPSindex].pps.maxVoltage * 100 >= targetVoltage) && (pdoData[PPSindex].pps.minVoltage * 100 <= targetVoltage))
     {
-        if ((pdoData[PPSindex].pps.maxVoltage * 100 >= targetVoltage) && (pdoData[PPSindex].pps.minVoltage * 100 <= targetVoltage)) // PPS exist, voltage satify
-        {
-            indexPDO = PPSindex;
-            reqPpsVolt = targetVoltage / 20; // Unit in 20mV/LBS
-            rdoData.pps.objPosition = PPSindex + 1; // index 1
-            rdoData.pps.opCurrent = pdoData[PPSindex].pps.maxCurrent;
-            rdoData.pps.voltage = reqPpsVolt;
-            writeRDO();
-            return;
-        }
+        indexPDO = PPSindex;
+        reqPpsVolt = targetVoltage / 20; // Unit in 20mV/LBS
+        rdoData.pps.objPosition = PPSindex + 1; // index 1
+        rdoData.pps.opCurrent = pdoData[PPSindex].pps.maxCurrent;
+        rdoData.pps.voltage = reqPpsVolt;
+        writeRDO();
+        return;
     }
     else
     {

--- a/AP33772.h
+++ b/AP33772.h
@@ -164,6 +164,7 @@ public:
   void writeRDO();
   int readVoltage();
   int readCurrent();
+  int getMaxCurrent() const;
   int readTemp();
   void printPDO();
   void reset();


### PR DESCRIPTION
Added a function that lets you request the maximum current available with the current PDO.
I have been using this to bound my encoder controls to the maximum allowable current

Modified setVoltage to allow usage of higher voltages outside of the PPS range.
Previous implementation only allowed PPS voltages on a PPS enabled supply.
My supply only supports 3.3V-11V in the PPS range but also has PDOs for 12V/15V/20V.