### PR TITLE
Load PDOs on begin, even if no newPDO flag

### DIFF
--- a/AP33772.cpp
+++ b/AP33772.cpp
@@ -48,7 +48,7 @@ void AP33772::begin()
     delay(10);
 
     // If negotiation is good, let's load in some PDOs from charger
-    if (event_flag.newNegoSuccess)      
+    if (event_flag.newNegoSuccess | event_flag.negoSuccess)
     {
         event_flag.newNegoSuccess = 0;
 


### PR DESCRIPTION
This way if the device is reset (such as after programming) it can still see the available power profiles.

(You'll want to update the relevant ["important note" section](https://github.com/CentyLab/PicoPD?tab=readme-ov-file#important-note) of the readme for the PicoPD too once this is merged in).