### PR TITLE
Correct 16mA/LSB to 24mA/LSB in readCurrent

### DIFF
--- a/AP33772.cpp
+++ b/AP33772.cpp
@@ -332,7 +332,7 @@ int AP33772::readVoltage()
 int AP33772::readCurrent()
 {
     i2c_read(AP33772_ADDRESS, CMD_CURRENT, 1);
-    return readBuf[0] * 16; // I2C read return 24mA/LSB
+    return readBuf[0] * 24; // I2C read return 24mA/LSB
 }
 
 /**


### PR DESCRIPTION
Following the datasheet for the AP33772 [found here](https://www.diodes.com/assets/Datasheets/AP33772.pdf) it looks like readCurrent should be returning **24** mA per LSB, not 16.

Please correct me if I've missed something :)