### PR TITLE
Add condition existPPS in setVoltage to resolve out-of-bounds memory access

### DIFF
--- a/AP33772.cpp
+++ b/AP33772.cpp
@@ -126,7 +126,7 @@ void AP33772::setVoltage(int targetVoltage)
                 tempIndex = i;
         }
         // Step 3: Compare found PDOs votlage and PPS max voltage
-        if (pdoData[tempIndex].fixed.voltage * 50 > pdoData[PPSindex].pps.maxVoltage * 100)
+        if (!existPPS || pdoData[tempIndex].fixed.voltage * 50 > pdoData[PPSindex].pps.maxVoltage * 100)
         {
             indexPDO = tempIndex;
             rdoData.fixed.objPosition = tempIndex + 1; // Index 0 to Index 1


### PR DESCRIPTION
Using **setVoltage** with a power supply that **does not** support PPS leads to out-of-bounds memory access. 

### Issue

If the power supply does not support PPS, **existPPS** will evaluate as **false**, meaning the first condition of setVoltage is unsatisfied:
```cpp
// AP33772.cpp line 110
if ((existPPS) && (pdoData[PPSindex].pps.maxVoltage * 100 >= targetVoltage) && (pdoData[PPSindex].pps.minVoltage * 100 <= targetVoltage))
```

It will then reach this condition in the else block:
```cpp
// AP33772.cpp line 129
if (pdoData[tempIndex].fixed.voltage * 50 > pdoData[PPSindex].pps.maxVoltage * 100)
```

At this point **PPSindex** has not been set, and is at it's default value of **8**, extending beyond the length of **pdoData**:
```cpp
// AP33772.h line 200
PDO_DATA_T pdoData[7] = {0};
```

### Resolution

Modify the condition on line 129 in AP33772.cpp to first check if **existPPS** evaluates as **false**:
```cpp
// AP33772.cpp line 129
if (!existPPS || pdoData[tempIndex].fixed.voltage * 50 > pdoData[PPSindex].pps.maxVoltage * 100)
```

The condition is then satisfied before the out-of-bound access. 

In the case that there is no PPS mode, the PDO with the closest fixed voltage should be used. While it may not match the target voltage, the function appears to be attempting to find the closest voltage to the request, not an exact match.

I have verified the edit is functional on my PicoPD.



